### PR TITLE
Delete page parameter on new search

### DIFF
--- a/files/web/static/js/cr/main/aktivuloj/index.js
+++ b/files/web/static/js/cr/main/aktivuloj/index.js
@@ -157,9 +157,11 @@ $(function () {
 	$('#search-form').submit(function (e) {
 		e.preventDefault();
 
+		searchParams.delete('p');
+
 		var search = $('#aktivulo-search').val()
 		if (search.length > 0) {
-			searchParams.set('s', search);	
+			searchParams.set('s', search);
 		} else {
 			searchParams.delete('s');
 		}


### PR DESCRIPTION
Kiam oni post serĉo iras al alia paĝo, kaj poste denove serĉas ion, oni aŭtomate alvenas ĉe la dua paĝo de la serĉrezultoj. Tio ŝajnas al mi kiel nedezirata funkcio.

Eĉ pli nedezirata estas, kiam oni iras al alia paĝo kaj poste serĉas (ekzemple) vicprezidantojn. Oni ricevas eraron, ke Centra Reto trovis neniun rezulton.

Komparu:
https://reto.tejo.org/aktivuloj?p=2&g=8
https://reto.tejo.org/aktivuloj?g=8

Forigi la paĝo-parametron post serĉo solvas la problemon.