### PR TITLE
Plibonigi montrado de priskriboj de eksteraj resursoj en malgrandaj ekranoj

### DIFF
--- a/files/web/static/js/cr/main/resursoj/listo.js
+++ b/files/web/static/js/cr/main/resursoj/listo.js
@@ -8,7 +8,6 @@ $(function () {
 		nameCol.textContent = row.name;
 		var descriptionCol = document.createElement('td');
 		descriptionCol.textContent = row.description;
-		descriptionCol.style.whiteSpace = "pre";
 		var urlCol = document.createElement('td');
 		var anchor = document.createElement('a');
 		urlCol.appendChild(anchor);


### PR DESCRIPTION
Saluton!

Uzante Centra Reto pere de mia poŝtelefono, mi rimarkis ke la priskriboj de eksteraj resursoj ne estas bone montrita en malgrandaj ekranoj.

Nuntempe montras kiel:
![priskribo-antaŭe](https://user-images.githubusercontent.com/1078000/60801887-1612f780-a178-11e9-8204-b4eff417cd6b.png)

Post ĉi tiu PR montros kiel:
![priskribo-poste](https://user-images.githubusercontent.com/1078000/60801899-19a67e80-a178-11e9-8909-664c72a2bfef.png)
